### PR TITLE
refactor: use googleUsers as default collection name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,5 +51,5 @@ FIREAUTH2_ENABLE_EXISTING_TOKEN_REVOCATION=
 
 # Name of the Firestore collection used to store authentication metadata
 # such as refresh tokens and linked user info.
-# Default: users
-FIREAUTH2_FIRESTORE_COLLECTION=users
+# Default: googleUsers
+FIREAUTH2_FIRESTORE_COLLECTION=googleUsers

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -5,7 +5,7 @@ use crate::impl_actix_from_request;
 const DEFAULT_FIREAUTH2_REDIRECT_URI_PATH: &str = "/callback";
 const DEFAULT_FIREAUTH2_SESSION_COOKIE_NAME: &str = "FIREAUTH2_SESSION";
 const DEFAULT_FIREAUTH2_SESSION_COOKIE_MAX_AGE: u16 = 180; // in seconds
-const DEFAULT_FIREAUTH2_FIRESTORE_COLLECTION: &str = "users";
+const DEFAULT_FIREAUTH2_FIRESTORE_COLLECTION: &str = "googleUsers";
 const DEFAULT_FIREAUTH2_ENABLE_EXISTING_TOKEN_REVOCATION: bool = false;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Renames the Google user collection to `googleUsers` to clearly differentiate it from the main `users` collection, which may store authenticated Firebase app users.

This separation avoids confusion between Firebase UIDs and Google OAuth subject IDs, and makes document structure and access patterns more explicit.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
