### PR TITLE
fix: support deserializing `include_granted_scopes` from JS clients

### DIFF
--- a/src/client/types/authorization.rs
+++ b/src/client/types/authorization.rs
@@ -1,168 +1,10 @@
-use chrono::Utc;
-use oauth2::{
-    AuthorizationCode, CsrfToken, ExtraTokenFields, PkceCodeVerifier, RefreshToken, TokenResponse,
-};
-use serde::{Deserialize, Deserializer, Serialize};
-use std::{borrow::Cow, fmt::Display, ops::Deref, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
+
+use oauth2::{CsrfToken, PkceCodeVerifier};
+use serde::{Deserialize, Serialize, de};
 use url::Url;
 
-use super::GoogleOAuthTokenResponse;
-
-/// Extra fields returned in Google's token response. We expect the `id_token`
-/// to be present so we can validate and extract user identity from it.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GoogleOAuthExtraTokenFields {
-    id_token: String,
-}
-
-impl ExtraTokenFields for GoogleOAuthExtraTokenFields {}
-
-impl GoogleOAuthExtraTokenFields {
-    pub fn id_token(&self) -> &str {
-        &self.id_token
-    }
-}
-
-/// Wraps a successful OAuth2 token exchange and provides a redirect URL
-/// to send the user to after login.
-#[derive(Debug, Clone)]
-pub struct AuthSuccessRedirectResponse {
-    pub redirect_url: Url,
-    pub token: GoogleOAuthTokenResponse,
-}
-
-impl AuthSuccessRedirectResponse {
-    pub fn new(redirect_url: Url, token: GoogleOAuthTokenResponse) -> Self {
-        Self {
-            redirect_url,
-            token,
-        }
-    }
-}
-
-impl Deref for AuthSuccessRedirectResponse {
-    type Target = GoogleOAuthTokenResponse;
-    fn deref(&self) -> &Self::Target {
-        &self.token
-    }
-}
-
-impl Display for AuthSuccessRedirectResponse {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let issued_at = Utc::now().timestamp();
-        let expires_in = self.expires_in().map(|d| d.as_secs()).unwrap_or(0);
-        write!(
-            f,
-            "{}#access_token={}&id_token={}&expires_in={}&issued_at={}",
-            self.redirect_url,
-            self.access_token().secret(),
-            self.extra_fields().id_token(),
-            expires_in,
-            issued_at
-        )
-    }
-}
-
-/// Wraps a successful OAuth2 token exchange and provides a redirect URL
-/// to send the user to after login.
-#[derive(Debug, Clone)]
-pub struct AuthErrorRedirectResponse {
-    pub redirect_url: Url,
-    pub error: String,
-}
-
-impl AuthErrorRedirectResponse {
-    pub fn new(redirect_url: Url, error: impl AsRef<str>) -> Self {
-        Self {
-            redirect_url,
-            error: error.as_ref().to_string(),
-        }
-    }
-}
-
-impl Display for AuthErrorRedirectResponse {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}#error={}",
-            self.redirect_url,
-            urlencoding::encode(&self.error)
-        )
-    }
-}
-
-#[derive(Debug)]
-pub struct ExchangeAuthorizationCodeRequest {
-    pub(crate) code: AuthorizationCode,
-    pub(crate) pkce_verifier: PkceCodeVerifier,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExchangeRefreshTokenRequest {
-    pub(crate) refresh_token: RefreshToken,
-}
-
-impl ExchangeRefreshTokenRequest {
-    pub fn new(refresh_token: impl AsRef<str>) -> Self {
-        Self {
-            refresh_token: RefreshToken::new(refresh_token.as_ref().to_owned()),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExchangeRefreshTokenResponse {
-    pub(crate) access_token: String,
-    pub(crate) id_token: String,
-    pub(crate) issued_at: i64,
-    pub(crate) expires_in: u64,
-}
-
-impl From<GoogleOAuthTokenResponse> for ExchangeRefreshTokenResponse {
-    fn from(value: GoogleOAuthTokenResponse) -> Self {
-        let issued_at = Utc::now().timestamp();
-        let expires_in = value.expires_in().map(|d| d.as_secs()).unwrap_or(0);
-        let access_token = value.access_token().clone();
-        Self {
-            access_token: access_token.into_secret(),
-            id_token: value.extra_fields().id_token().to_owned(),
-            issued_at,
-            expires_in,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct ExtraParam(&'static str);
-
-impl Deref for ExtraParam {
-    type Target = str;
-    fn deref(&self) -> &Self::Target {
-        self.0
-    }
-}
-
-impl ExtraParam {
-    pub const INCLUDE_GRANTED_SCOPES: ExtraParam = ExtraParam("include_granted_scopes");
-    pub const LOGIN_HINT: ExtraParam = ExtraParam("login_hint");
-    pub const ACCESS_TYPE: ExtraParam = ExtraParam("access_type");
-    pub const PROMPT: ExtraParam = ExtraParam("prompt");
-
-    pub fn into_cow<'a>(&self) -> Cow<'a, str> {
-        Cow::Borrowed(self.0)
-    }
-}
-
-pub trait IntoExtraParam<'a> {
-    fn into_extra_param(self) -> (ExtraParam, Cow<'a, str>);
-}
-
-pub trait ToExtraParams<'a> {
-    /// Converts **self** into a list of query parameters for the authorization request.
-    fn to_extra_params(&self) -> Vec<(ExtraParam, Cow<'a, str>)>;
-}
+use super::extra_params::{ExtraParam, IntoExtraParam, ToExtraParams};
 
 /// Indicates whether your application can refresh access tokens
 /// when the user is not present at the browser.
@@ -183,7 +25,7 @@ pub enum AccessType {
     Offline,
 }
 
-impl Display for AccessType {
+impl fmt::Display for AccessType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Offline => write!(f, "offline"),
@@ -234,7 +76,7 @@ impl FromStr for Prompt {
     }
 }
 
-impl Display for Prompt {
+impl fmt::Display for Prompt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::None => write!(f, "none"),
@@ -264,7 +106,10 @@ pub struct RequestAccessTokenExtraParams {
     /// is granted, the authorization will include any previous authorizations granted
     /// to this user/application combination for other scopes; see Incremental authorization.
     /// Note that you cannot do incremental authorization with the Installed App flow.
-    #[serde(default = "return_granted_scopes")]
+    #[serde(
+        default = "include_granted_scopes",
+        deserialize_with = "deserialize_bool"
+    )]
     pub(crate) include_granted_scopes: bool,
 
     /// If your application knows which user is trying to authenticate, it can use
@@ -285,35 +130,7 @@ pub struct RequestAccessTokenExtraParams {
     pub(crate) prompt: Vec<Prompt>,
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum PromptInput {
-    List(Vec<Prompt>),
-    String(Prompt),
-}
-
-fn deserialize_prompt_vec<'de, D>(deserializer: D) -> Result<Vec<Prompt>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let input = PromptInput::deserialize(deserializer)?;
-
-    match input {
-        PromptInput::List(list) => Ok(list),
-        PromptInput::String(s) => s
-            .to_string()
-            .split(',')
-            .filter(|part| !part.trim().is_empty())
-            .map(|part| {
-                Prompt::from_str(part.trim()).map_err(|_| {
-                    serde::de::Error::custom(format!("Invalid prompt value: '{}'", part.trim()))
-                })
-            })
-            .collect(),
-    }
-}
-
-fn return_granted_scopes() -> bool {
+fn include_granted_scopes() -> bool {
     true
 }
 
@@ -345,6 +162,68 @@ impl<'a> ToExtraParams<'a> for RequestAccessTokenExtraParams {
         params.push(self.prompt.clone().into_extra_param());
 
         params
+    }
+}
+
+fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    struct StringOrBoolVisitor;
+
+    impl<'de> de::Visitor<'de> for StringOrBoolVisitor {
+        type Value = bool;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str(r#""true", "false", true, or false"#)
+        }
+
+        fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(v)
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match v {
+                "true" => Ok(true),
+                "false" => Ok(false),
+                _ => Err(de::Error::unknown_variant(v, &["true", "false"])),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(StringOrBoolVisitor)
+}
+
+pub(in crate::client) fn deserialize_prompt_vec<'de, D>(
+    deserializer: D,
+) -> Result<Vec<Prompt>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum PromptInput {
+        List(Vec<Prompt>),
+        String(Prompt),
+    }
+
+    let input = PromptInput::deserialize(deserializer)?;
+
+    match input {
+        PromptInput::List(list) => Ok(list),
+        PromptInput::String(s) => s
+            .to_string()
+            .split(',')
+            .filter(|part| !part.trim().is_empty())
+            .map(|part| {
+                Prompt::from_str(part.trim()).map_err(|_| {
+                    serde::de::Error::custom(format!("Invalid prompt value: '{}'", part.trim()))
+                })
+            })
+            .collect(),
     }
 }
 

--- a/src/client/types/exchange.rs
+++ b/src/client/types/exchange.rs
@@ -1,0 +1,47 @@
+use oauth2::{AuthorizationCode, PkceCodeVerifier, RefreshToken, TokenResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::client::GoogleOAuthTokenResponse;
+
+#[derive(Debug)]
+pub struct ExchangeAuthorizationCodeRequest {
+    pub(crate) code: AuthorizationCode,
+    pub(crate) pkce_verifier: PkceCodeVerifier,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeRefreshTokenRequest {
+    pub(crate) refresh_token: RefreshToken,
+}
+
+impl ExchangeRefreshTokenRequest {
+    pub fn new(refresh_token: impl AsRef<str>) -> Self {
+        Self {
+            refresh_token: RefreshToken::new(refresh_token.as_ref().to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeRefreshTokenResponse {
+    pub(crate) access_token: String,
+    pub(crate) id_token: String,
+    pub(crate) issued_at: i64,
+    pub(crate) expires_in: u64,
+}
+
+impl From<GoogleOAuthTokenResponse> for ExchangeRefreshTokenResponse {
+    fn from(value: GoogleOAuthTokenResponse) -> Self {
+        let issued_at = chrono::Utc::now().timestamp();
+        let expires_in = value.expires_in().map(|d| d.as_secs()).unwrap_or(0);
+        let access_token = value.access_token().clone();
+        Self {
+            access_token: access_token.into_secret(),
+            id_token: value.extra_fields().id_token().to_owned(),
+            issued_at,
+            expires_in,
+        }
+    }
+}

--- a/src/client/types/extra_fields.rs
+++ b/src/client/types/extra_fields.rs
@@ -1,0 +1,17 @@
+use oauth2::ExtraTokenFields;
+use serde::{Deserialize, Serialize};
+
+/// Extra fields returned in Google's token response. We expect the `id_token`
+/// to be present so we can validate and extract user identity from it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleOAuthExtraTokenFields {
+    id_token: String,
+}
+
+impl ExtraTokenFields for GoogleOAuthExtraTokenFields {}
+
+impl GoogleOAuthExtraTokenFields {
+    pub fn id_token(&self) -> &str {
+        &self.id_token
+    }
+}

--- a/src/client/types/extra_params.rs
+++ b/src/client/types/extra_params.rs
@@ -1,0 +1,33 @@
+use std::{borrow::Cow, ops::Deref};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ExtraParam(&'static str);
+
+impl Deref for ExtraParam {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl ExtraParam {
+    pub const INCLUDE_GRANTED_SCOPES: ExtraParam = ExtraParam("include_granted_scopes");
+    pub const LOGIN_HINT: ExtraParam = ExtraParam("login_hint");
+    pub const ACCESS_TYPE: ExtraParam = ExtraParam("access_type");
+    pub const PROMPT: ExtraParam = ExtraParam("prompt");
+
+    pub fn into_cow<'a>(&self) -> Cow<'a, str> {
+        Cow::Borrowed(self.0)
+    }
+}
+
+pub trait IntoExtraParam<'a> {
+    fn into_extra_param(self) -> (ExtraParam, Cow<'a, str>);
+}
+
+pub trait ToExtraParams<'a> {
+    /// Converts **self** into a list of query parameters for the authorization request.
+    fn to_extra_params(&self) -> Vec<(ExtraParam, Cow<'a, str>)>;
+}

--- a/src/client/types/mod.rs
+++ b/src/client/types/mod.rs
@@ -1,0 +1,11 @@
+mod exchange;
+mod extra_fields;
+mod extra_params;
+mod authorization;
+mod redirect;
+
+pub use exchange::*;
+pub use extra_fields::*;
+pub use extra_params::*;
+pub use authorization::*;
+pub use redirect::*;

--- a/src/client/types/redirect.rs
+++ b/src/client/types/redirect.rs
@@ -1,0 +1,73 @@
+use std::{fmt, ops::Deref};
+
+use oauth2::TokenResponse;
+use url::Url;
+
+use crate::client::GoogleOAuthTokenResponse;
+
+/// Wraps a successful OAuth2 token exchange and provides a redirect URL
+/// to send the user to after login.
+#[derive(Debug, Clone)]
+pub struct AuthRedirectSuccessResponse {
+    pub redirect_url: Url,
+    pub token: GoogleOAuthTokenResponse,
+}
+
+impl AuthRedirectSuccessResponse {
+    pub fn new(redirect_url: Url, token: GoogleOAuthTokenResponse) -> Self {
+        Self {
+            redirect_url,
+            token,
+        }
+    }
+}
+
+impl Deref for AuthRedirectSuccessResponse {
+    type Target = GoogleOAuthTokenResponse;
+    fn deref(&self) -> &Self::Target {
+        &self.token
+    }
+}
+
+impl fmt::Display for AuthRedirectSuccessResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let issued_at = chrono::Utc::now().timestamp();
+        let expires_in = self.token.expires_in().map(|d| d.as_secs()).unwrap_or(0);
+        write!(
+            f,
+            "{}#access_token={}&id_token={}&expires_in={}&issued_at={}",
+            self.redirect_url,
+            self.token.access_token().secret(),
+            self.token.extra_fields().id_token(),
+            expires_in,
+            issued_at
+        )
+    }
+}
+
+/// Wraps an error OAuth2 token exchange and provides a redirect URL to send the user to.
+#[derive(Debug, Clone)]
+pub struct AuthRedirectErrorResponse {
+    pub redirect_url: Url,
+    pub error: String,
+}
+
+impl AuthRedirectErrorResponse {
+    pub fn new(redirect_url: Url, error: impl AsRef<str>) -> Self {
+        Self {
+            redirect_url,
+            error: error.as_ref().to_string(),
+        }
+    }
+}
+
+impl fmt::Display for AuthRedirectErrorResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}#error={}",
+            self.redirect_url,
+            urlencoding::encode(&self.error)
+        )
+    }
+}

--- a/src/web/routes/callback.rs
+++ b/src/web/routes/callback.rs
@@ -1,7 +1,7 @@
 use crate::Result;
-use crate::client::AuthErrorRedirectResponse;
 use crate::client::{
-    AuthSuccessRedirectResponse, ExchangeAuthorizationCodeRequest, GoogleOAuthClient,
+    AuthRedirectErrorResponse, AuthRedirectSuccessResponse, ExchangeAuthorizationCodeRequest,
+    GoogleOAuthClient,
 };
 use crate::models::user::GoogleUser;
 use crate::web::AppState;
@@ -163,7 +163,7 @@ pub async fn exchange_authorization_code(
     };
 
     // Redirect to success handler with tokens in URL fragment
-    let redirect_url = AuthSuccessRedirectResponse::new(session.redirect_to, response);
+    let redirect_url = AuthRedirectSuccessResponse::new(session.redirect_to, response);
     let response = HttpResponse::Found()
         .append_header((header::LOCATION, redirect_url.to_string()))
         .finish();
@@ -173,7 +173,7 @@ pub async fn exchange_authorization_code(
 
 /// Redirects back to the client with an error encoded in the URL fragment.
 fn respond_with_error(redirect_url: Url, error: impl AsRef<str>) -> Result<HttpResponse> {
-    let redirect_url = AuthErrorRedirectResponse::new(redirect_url, error);
+    let redirect_url = AuthRedirectErrorResponse::new(redirect_url, error);
     let response = HttpResponse::Found()
         .append_header((header::LOCATION, redirect_url.to_string()))
         .finish();


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->
Fixes an issue, where JS clients where unable to set the `include_granted_scopes` parameter when starting an authorization session.

This change also refactors the types layout for improved maintainability.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
