### PR TITLE
feat: support user-defined OAuth scopes

### DIFF
--- a/fireauth2/src/client/config.rs
+++ b/fireauth2/src/client/config.rs
@@ -1,8 +1,5 @@
 use base64::Engine;
-use oauth2::{
-    AuthUrl, ClientId, ClientSecret, RedirectUrl, RevocationUrl, Scope,
-    TokenUrl,
-};
+use oauth2::{AuthUrl, ClientId, ClientSecret, RevocationUrl, TokenUrl};
 use serde::Deserialize;
 
 #[derive(Clone, Deserialize)]
@@ -29,20 +26,6 @@ impl GoogleOAuthClientConfig {
     const CLIENT_CONFIG_VAR: &'static str = "GOOGLE_OAUTH_CLIENT_CONFIG";
     const REVOCATION_URL: &'static str = "https://oauth2.googleapis.com/revoke";
 
-    const SCOPES: &'static [&str] = &[
-        "email",
-        "openid",
-        "profile",
-        "https://www.googleapis.com/auth/datastore",
-    ];
-
-    pub fn scopes() -> Vec<Scope> {
-        Self::SCOPES
-            .iter()
-            .map(|s| Scope::new((*s).to_owned()))
-            .collect()
-    }
-
     pub fn token_uri(&self) -> crate::Result<TokenUrl> {
         let url = TokenUrl::new(self.web.token_uri.to_string())?;
         Ok(url)
@@ -64,13 +47,6 @@ impl GoogleOAuthClientConfig {
 
     pub fn allowed_origins(&self) -> &Vec<url::Url> {
         self.web.javascript_origins.as_ref()
-    }
-
-    // TODO: May be no longer needed
-    pub fn redirect_uri() -> crate::Result<RedirectUrl> {
-        let redirect_url = "http://localhost:8080/callback";
-        let redirect_url = RedirectUrl::new(redirect_url.to_owned())?;
-        Ok(redirect_url)
     }
 
     pub fn client_id(&self) -> ClientId {


### PR DESCRIPTION
## 📑 Description

In our previous implementation of `GoogleOAuthClient`, OAuth scopes were statically defined in and derived from the `GoogleOAuthClientConfig` config struct each time a web client requested a new access token.

This commit enables web clients to specify desired OAuth scopes when requesting a new authorization URL by providing scopes as space-delimited string in the `scope` query parameter as part of an authorization request.

However, this change also requires us to think differently about how to handle and store a `refresh_token`, if one is returned by Google's OAuth server.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #13 <!-- Issue # here -->

<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
